### PR TITLE
[RTM]: use window.history.back instead of url previous

### DIFF
--- a/resources/views/exercises/edit-exercise.blade.php
+++ b/resources/views/exercises/edit-exercise.blade.php
@@ -94,7 +94,7 @@
                             </div>
 
                             <div class="my-3 d-flex">
-                                <a href="{{ url()->previous() }}">
+                                <a href="javascript:window.history.back()">
                                     <button type="button" class="btn btn-outline-secondary btn-lg px-4 gap-3">Zrušit</button>
                                 </a>
                                 <button type="submit" class="btn btn-primary btn-lg px-3 ms-auto me-0">Upravit cvičení</button>

--- a/resources/views/groups/edit-group.blade.php
+++ b/resources/views/groups/edit-group.blade.php
@@ -119,7 +119,7 @@
                             </div>
 
                             <div class="my-3 d-flex">
-                                <a href="{{ url()->previous() }}">
+                                <a href="javascript:window.history.back()">
                                     <input type="button" class="btn btn-outline-secondary btn-lg px-4 gap-3" value="Zrušit">
                                 </a>
                                 <button type="submit" class="btn btn-primary btn-lg px-3 ms-auto me-0">Upravit skupinu</button>

--- a/resources/views/groups/show-group.blade.php
+++ b/resources/views/groups/show-group.blade.php
@@ -4,6 +4,12 @@
     <div class="container my-4">
         <div class="row justify-content-center">
             <div class="col-md-10">
+                <div class="my-3 row d-flex">
+                    <a href="javascript:window.history.back()">
+                        <input type="button" class="btn btn-outline-secondary btn-md px-3" value="Zpět">
+                    </a>
+                </div>
+
                 <div class="card">
                     <div class="card-header">{{ __('Zobrazení skupiny') }}
                     </div>
@@ -118,12 +124,6 @@
                                     </div>
                                 </div>
                             @endif
-                        </div>
-
-                        <div class="my-3 row d-flex">
-                            <a href="javascript:window.history.back()">
-                                <input type="button" class="btn btn-outline-secondary btn-lg px-4" value="Zpět">
-                            </a>
                         </div>
                     </div>
                 </div>

--- a/resources/views/groups/show-group.blade.php
+++ b/resources/views/groups/show-group.blade.php
@@ -121,7 +121,7 @@
                         </div>
 
                         <div class="my-3 row d-flex">
-                            <a href="{{ url()->previous() }}">
+                            <a href="javascript:window.history.back()">
                                 <input type="button" class="btn btn-outline-secondary btn-lg px-4" value="Zpět">
                             </a>
                         </div>

--- a/resources/views/profile/edit.blade.php
+++ b/resources/views/profile/edit.blade.php
@@ -10,7 +10,7 @@
                             {{ __('Úprava profilu') }}
                         </div>
                         <div class="ms-auto">
-                            <a href="@if(Auth::user()->account_type == 'admin'){{route('user-administration')}}@else{{route('profile')}}@endif"
+                            <a href="javascript:window.history.back()"
                                style="text-decoration: none">
                                 <button class="btn btn-outline-secondary me-2">
                                     Zrušit
@@ -202,7 +202,7 @@
                             <button id="submitBtn" name="submitBtn" class="btn btn-outline-success"
                                     onclick="validateFormAndSubmit()">Uložit
                             </button>
-                            <a href="@if(Auth::user()->account_type == 'admin'){{route('user-administration')}}@else{{route('profile')}}@endif"
+                            <a href="javascript:window.history.back()"
                                style="text-decoration: none">
                                 <button class="btn btn-outline-secondary ms-2">
                                     Zrušit

--- a/resources/views/profile/show.blade.php
+++ b/resources/views/profile/show.blade.php
@@ -4,11 +4,11 @@
     <div class="container my-4">
         <div class="row justify-content-center">
             <div class="col-md-10">
-                @if($user['id'] != Auth::id())
+                <div class="my-3 row d-flex">
                     <a href="javascript:window.history.back()">
-                        <button class="btn btn-outline-secondary mb-2">Zpět</button>
+                        <input type="button" class="btn btn-outline-secondary btn-md px-3" value="Zpět">
                     </a>
-                @endif
+                </div>
                 <div class="card">
                     <div class="card-header d-flex align-items-center">
                         <div>{{ __('Zobrazení profilu') }}</div>

--- a/resources/views/profile/show.blade.php
+++ b/resources/views/profile/show.blade.php
@@ -5,7 +5,7 @@
         <div class="row justify-content-center">
             <div class="col-md-10">
                 @if($user['id'] != Auth::id())
-                    <a href="{{url()->previous()}}">
+                    <a href="javascript:window.history.back()">
                         <button class="btn btn-outline-secondary mb-2">Zpět</button>
                     </a>
                 @endif

--- a/resources/views/statistics/user-statistics.blade.php
+++ b/resources/views/statistics/user-statistics.blade.php
@@ -109,7 +109,7 @@
                         @endempty
 
                         <div class="my-3 row d-flex">
-                            <a href="{{ url()->previous() }}">
+                            <a href="javascript:window.history.back()">
                                 <input type="button" class="btn btn-outline-secondary btn-lg px-4" value="Zpět">
                             </a>
                         </div>


### PR DESCRIPTION
The pr replaces the url()->previous() with window.history.back() from javascript. With that, the back button really works like that it just move only backward.

- [x] Move back button on the show-group view as on the user profile detail